### PR TITLE
Add team color visualization tool, improve index pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,23 @@
-<html>
-<body>
-<a href="load_map.html">demo viewer</a> based on <a href="https://github.com/Jupeyy/ddnet/tree/web_preview">some modifications</a>
-</body>
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>DDNet Tools</title>
+		<style>
+			body {
+				background: #ccc;
+				font-family: sans-serif;
+			}
+			h1 {
+				font-size: 16pt;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Demo and Map Viewer</h1>
+		<p><a href="load_map.html">Demo and Map Viewer</a> based on DDNet with <a href="https://github.com/Jupeyy/ddnet/tree/web_preview">some modifications</a>.</p>
+		<h1>Team Color Visualization</h1>
+		<p><a href="team-colors.html">Team Color Visualization</a> before and after the team colors where <a href="https://github.com/ddnet/ddnet/pull/7129">changed to use the golden angle</a>.</p>
+	</body>
 </html>

--- a/load_map.html
+++ b/load_map.html
@@ -1,33 +1,42 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 	<head>
 		<meta charset="utf-8">
-		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Demo and Map Viewer</title>
 		<style>
-		.game {
-			position: absolute;
-			top: 500px;
-			left: 0px;
-			margin: 0px;
-			border: 0;
-			width: 100%;
-			height: 100%;
-			overflow: hidden;
-			display: block;
-		}
+			body {
+				background: #ccc;
+				font-family: sans-serif;
+			}
+			h1 {
+				font-size: 16pt;
+			}
+			.game {
+				position: absolute;
+				top: 500px;
+				left: 0px;
+				margin: 0px;
+				border: 0;
+				width: 100%;
+				height: 100%;
+				overflow: hidden;
+				display: block;
+			}
 		</style>
 		<script src="enable-threads.js"></script>
 	</head>
 	<body onload="OnLoad();">
-		<canvas class="game" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+		<canvas class="game" id="canvas" oncontextmenu="event.preventDefault();"></canvas>
 
-		<h1 id="renderdemos">Render demos</h1>
-		<form position="absolute" action='#' onsubmit="() => { return false; }">
+		<h1 id="renderdemos">Render Demo</h1>
+		<form action='#' onsubmit="() => { return false; }">
 			<input type='file' id='DemoFileInput'>
 			<input type='button' id='DemoFileLoad' value='Load' onclick='LoadDemoFile();'>
 		</form>
 
-		<h1 id="rendermap">Render map</h1>
-		<form position="absolute" action='#' onsubmit="() => { return false; }">
+		<h1 id="rendermap">Render Map</h1>
+		<form action='#' onsubmit="() => { return false; }">
 			<input type='file' id='MapFileInput'>
 			<input type='button' id='MapFileLoad' value='Load' onclick='LoadMapFile();'>
 		</form>

--- a/team-colors.html
+++ b/team-colors.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<title>Team Color Visualization</title>
+		<style>
+			body {
+				background: #ccc;
+				font-family: sans-serif;
+			}
+			h1 {
+				font-size: 16pt;
+			}
+			.colorGroup {
+				display: flex;
+				flex-wrap: wrap;
+				margin: 0;
+				padding: 0;
+			}
+			.colorGroup > div {
+				width: 32px;
+				height: 32px;
+				box-sizing: border-box;
+				border: 1px solid #333;
+				margin: 2px;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				font-weight: bold;
+			}
+		</style>
+	</head>
+	<body>
+		<h1>Version 17.2 and older</h1>
+		<div id="old" class="colorGroup"></div>
+		<h1>Version 17.3 and newer</h1>
+		<div id="new" class="colorGroup"></div>
+		<h1>Version 17.3 and newer (sorted by hue)</h1>
+		<div id="newSorted" class="colorGroup"></div>
+		<script>
+			function generateDivs() {
+				for (let i = 0; i < 64; i++) {
+					const div = document.createElement("div");
+					const hue = i * 360.0/64.0;
+					div.style.backgroundColor = `hsl(${hue}, 100%, 50%)`;
+					div.textContent = (i + 1);
+					document.getElementById("old").appendChild(div);
+				}
+				const newDivs = [];
+				for (let i = 0; i < 64; i++) {
+					const div = document.createElement("div");
+					const hue = (i * 137.50776) % 360.0;
+					div.style.backgroundColor = `hsl(${hue}, 100%, 50%)`;
+					div.textContent = (i + 1);
+					newDivs.push({div: div, hue: hue});
+				}
+				for (const divObject of newDivs) {
+					document.getElementById("new").appendChild(divObject.div.cloneNode(true));
+				}
+				newDivs.sort((a, b) => a.hue - b.hue);
+				for (const divObject of newDivs) {
+					document.getElementById("newSorted").appendChild(divObject.div);
+				}
+			}
+			window.onload = generateDivs;
+		</script>
+	</body>
+</html>


### PR DESCRIPTION
Add the tool used to visualize the team color change of ddnet/ddnet#7129.

![Screenshot 2024-06-16 at 15-40-09 Team Color](https://github.com/ddnet/ddnet.github.io/assets/23437060/cfd7b4d4-3b3d-46c0-ad21-2ee5ead69fe2)

Improve the layout of the index page and also add the team color tool to it.

![image](https://github.com/ddnet/ddnet.github.io/assets/23437060/5954ca76-b9f1-4591-92ef-569f33b867eb)

Make the layout of Map and Demo Viewer index page consistent with this. Remove unnecessary duplicate specification of the UTF-8 encoding. Add viewport specification.

![image](https://github.com/ddnet/ddnet.github.io/assets/23437060/74b00f44-5195-4e84-aeb9-12fcf1e3b94c)